### PR TITLE
feat: add Last.fm CSV import utility

### DIFF
--- a/backend/src/import-lastfm.ts
+++ b/backend/src/import-lastfm.ts
@@ -1,19 +1,24 @@
-#tested with https://lastfm.ghan.nl/export/ csv export
-
 import { readFileSync } from "node:fs";
 import Database from "better-sqlite3";
-import { buildIndex, classify } from "/app/dist/import/spotify.js";
-import { openStatsDb } from "/app/dist/db/stats-db.js";
-import { EventStore } from "/app/dist/events/store.js";
+import { buildIndex, classify } from "./import/spotify.js";
+import type { NavTrack } from "./import/spotify.js";
+import { openStatsDb } from "./db/stats-db.js";
+import { EventStore } from "./events/store.js";
 
 function parseCsvLine(line: string): string[] {
   const result: string[] = [];
   let current = "";
   let quoted = false;
 
-  for (const char of line) {
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
     if (char === '"') {
-      quoted = !quoted;
+      if (quoted && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        quoted = !quoted;
+      }
     } else if (char === "," && !quoted) {
       result.push(current);
       current = "";
@@ -28,8 +33,9 @@ function parseCsvLine(line: string): string[] {
 
 function loadLastFm(file: string) {
   const lines = readFileSync(file, "utf8")
-  .split("\n")
-  .filter(Boolean);
+    .split("\n")
+    .map((l) => l.replace(/\r$/, ""))
+    .filter(Boolean);
 
   const headers = parseCsvLine(lines[0]);
 
@@ -42,11 +48,11 @@ function loadLastFm(file: string) {
 
     return {
       ts: new Date(Number(row.uts) * 1000).toISOString(),
-                            ms_played: 240000,
-                            track: row.track || null,
-                            artist: row.artist || null,
-                            album: row.album || null,
-                            uri: null,
+      ms_played: 240000,
+      track: row.track || null,
+      artist: row.artist || null,
+      album: row.album || null,
+      uri: null,
     };
   });
 }
@@ -79,7 +85,18 @@ async function main() {
   }
 
   if (!cfg.user) {
-    throw new Error("DEFAULT_USER missing");
+    console.error("Error: DEFAULT_USER env var required.");
+    process.exit(1);
+  }
+
+  if (!cfg.navidrome) {
+    console.error("Error: NAVIDROME_DB_PATH env var required.");
+    process.exit(1);
+  }
+
+  if (cfg.commit && !cfg.stats) {
+    console.error("Error: STATS_DB_PATH env var required for --commit.");
+    process.exit(1);
   }
 
   console.log("Loading Last.fm CSV...");
@@ -96,10 +113,10 @@ async function main() {
   });
 
   const tracks = navDb
-  .prepare(
-    "SELECT id, title, artist, duration FROM media_file"
-  )
-  .all();
+    .prepare(
+      "SELECT id, title, artist, duration FROM media_file"
+    )
+    .all() as NavTrack[];
 
   navDb.close();
 

--- a/backend/src/import-lastfm.ts
+++ b/backend/src/import-lastfm.ts
@@ -1,0 +1,167 @@
+#tested with https://lastfm.ghan.nl/export/ csv export
+
+import { readFileSync } from "node:fs";
+import Database from "better-sqlite3";
+import { buildIndex, classify } from "/app/dist/import/spotify.js";
+import { openStatsDb } from "/app/dist/db/stats-db.js";
+import { EventStore } from "/app/dist/events/store.js";
+
+function parseCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = "";
+  let quoted = false;
+
+  for (const char of line) {
+    if (char === '"') {
+      quoted = !quoted;
+    } else if (char === "," && !quoted) {
+      result.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current);
+  return result;
+}
+
+function loadLastFm(file: string) {
+  const lines = readFileSync(file, "utf8")
+  .split("\n")
+  .filter(Boolean);
+
+  const headers = parseCsvLine(lines[0]);
+
+  return lines.slice(1).map((line) => {
+    const values = parseCsvLine(line);
+
+    const row = Object.fromEntries(
+      headers.map((h, i) => [h, values[i] ?? ""])
+    );
+
+    return {
+      ts: new Date(Number(row.uts) * 1000).toISOString(),
+                            ms_played: 240000,
+                            track: row.track || null,
+                            artist: row.artist || null,
+                            album: row.album || null,
+                            uri: null,
+    };
+  });
+}
+
+function parseArgs(argv: string[]) {
+  return {
+    csv: argv[2],
+    commit: argv.includes("--commit"),
+    user: process.env.DEFAULT_USER ?? "",
+    navidrome: process.env.NAVIDROME_DB_PATH ?? "",
+    stats: process.env.STATS_DB_PATH ?? "",
+  };
+}
+
+function startMonitor(label: string) {
+  const started = Date.now();
+
+  return setInterval(() => {
+    const seconds = Math.floor((Date.now() - started) / 1000);
+    console.log(`${label} running... ${seconds}s`);
+  }, 10000);
+}
+
+async function main() {
+  const cfg = parseArgs(process.argv);
+
+  if (!cfg.csv) {
+    console.error("Usage: import-lastfm <file.csv> [--commit]");
+    process.exit(1);
+  }
+
+  if (!cfg.user) {
+    throw new Error("DEFAULT_USER missing");
+  }
+
+  console.log("Loading Last.fm CSV...");
+
+  const plays = loadLastFm(cfg.csv);
+
+  console.log(`Loaded ${plays.length} Last.fm plays`);
+
+  console.log("Opening Navidrome database...");
+
+  const navDb = new Database(cfg.navidrome, {
+    readonly: true,
+    fileMustExist: true,
+  });
+
+  const tracks = navDb
+  .prepare(
+    "SELECT id, title, artist, duration FROM media_file"
+  )
+  .all();
+
+  navDb.close();
+
+  console.log(`Loaded ${tracks.length} Navidrome tracks`);
+
+  console.log("Building track index...");
+
+  const indexStart = Date.now();
+
+  const index = buildIndex(tracks);
+
+  console.log(
+    `Index built in ${((Date.now() - indexStart) / 1000).toFixed(1)}s`
+  );
+
+  console.log("Matching Last.fm plays...");
+
+  const monitor = startMonitor("Matching");
+
+  const report = classify(
+    plays,
+    index,
+    30000
+  );
+
+  clearInterval(monitor);
+
+  console.log("");
+  console.log("Import summary:");
+  console.log(`  Counted: ${report.counted}`);
+  console.log(`  Matched: ${report.matched}`);
+  console.log(`  Exact: ${report.matchedExact}`);
+  console.log(`  Title only: ${report.matchedByTitle}`);
+  console.log(`  Missing: ${report.unmatched}`);
+
+  if (!cfg.commit) {
+    console.log("");
+    console.log(
+      "DRY RUN - rerun with --commit to import"
+    );
+    return;
+  }
+
+  console.log("Writing events...");
+
+  const statsDb = openStatsDb(cfg.stats);
+
+  const store = new EventStore(statsDb);
+
+  const inserted = store.insertImport(
+    report.events,
+    cfg.user
+  );
+
+  console.log(
+    `Inserted ${inserted}, skipped ${report.events.length - inserted} duplicates`
+  );
+
+  statsDb.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds a CLI utility to import listening history from Last.fm CSV exports generated by https://lastfm.ghan.nl/export/

The importer:

* Parses Last.fm CSV exports.
* Matches plays against the Navidrome library using the existing track classifier.
* Skips duplicate events during import.
* Performs a dry run by default.
* Imports events when run with the `--commit` flag.

Example:

**Dry run:**
docker exec -it spindle-backend \
npx tsx /backend/src/import-lastfm.ts \
/app/data/last.fm/xxx.csv

**Commit import:**
docker exec -it spindle-backend \
npx tsx /backend/src/import-lastfm.ts \
/app/data/last.fm/xxx.csv \
--commit
